### PR TITLE
fix: relax php authoring doc rules

### DIFF
--- a/coderabbit/php/authoring/v1/.coderabbit.yaml
+++ b/coderabbit/php/authoring/v1/.coderabbit.yaml
@@ -29,6 +29,14 @@ reviews:
     - path: '**'
       instructions: |
         ## General Project Standards
+        ### Commit & PR Rules
+        - Branch naming MUST follow: `fix|feat/{TICKET}/short-description`.
+        - Commits MUST use Conventional Commits (e.g., `fix: summary`).
+        - PRs MUST target `develop`.
+        - PR description MUST be `.notes/pr-description/{ticket}.md`.
+        - PRs MUST link Jira/GitHub issues, list impacted services, and include test evidence plus UI screenshots.
+        - PR creation MUST include reviewers: `tikhanovichA`, `KirylHatalski`, `pnal`, `Karol-Stelmaczonek`.
+
         ### Security & Performance
         - Implement proper input validation and sanitization.
         - Use parameterized queries to prevent SQL injection.
@@ -148,3 +156,4 @@ reviews:
         - Tests: Write unit tests for all new code. Tests must be isolated and cover both positive and negative scenarios. `tests/` is the required directory name.
         - Locales: Support PO/RDF formats. Use consistent, meaningful message keys/IDs.
         - Views: Use semantic HTML, ensure responsive design (WCAG 2.1 compliance), and optimize assets with a Content Security Policy (CSP).
+        - Views (JS): Review source files only; do not request edits to minified bundles and do not treat missing minified updates as blocking.

--- a/coderabbit/php/authoring/v1/.coderabbit.yaml
+++ b/coderabbit/php/authoring/v1/.coderabbit.yaml
@@ -92,8 +92,8 @@ reviews:
         
         ### Documentation
         - Write self-documenting code with meaningful variable and method names.
-        - All classes MUST have DocBlock headers with license information.
-        - All public methods MUST have proper @param and @return annotations.
+        - All classes MUST have DocBlock headers with license information, except classes under tests/ (e.g., tests/**).
+        - All public methods MAY have proper @param and @return annotations.
         
         ### Type System & Error Handling
         - Use strict types `declare(strict_types=1);` in all PHP files.

--- a/coderabbit/php/authoring/v1/.coderabbit.yaml
+++ b/coderabbit/php/authoring/v1/.coderabbit.yaml
@@ -30,12 +30,10 @@ reviews:
       instructions: |
         ## General Project Standards
         ### Commit & PR Rules
-        - Branch naming MUST follow: `fix|feat/{TICKET}/short-description`.
         - Commits MUST use Conventional Commits (e.g., `fix: summary`).
         - PRs MUST target `develop`.
         - PR description MUST be `.notes/pr-description/{ticket}.md`.
         - PRs MUST link Jira/GitHub issues, list impacted services, and include test evidence plus UI screenshots.
-        - PR creation MUST include reviewers: `tikhanovichA`, `KirylHatalski`, `pnal`, `Karol-Stelmaczonek`.
 
         ### Security & Performance
         - Implement proper input validation and sanitization.


### PR DESCRIPTION
## Summary
- exclude tests/** from license DocBlock requirement
- make public method annotations optional (MAY)

## Testing
- not run (no tests in this repo)

## Validation
- TODO: link to target repo PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Commit & PR rules: Conventional Commits, PRs target develop, include issue links, impacted services, test evidence and UI screenshots.
  * Updated documentation standards: require DocBlock headers with license for classes (tests exempt); @param/@return for public methods now optional.
  * Testing guidance: when reviewing views (JS), review source files only; minified bundle updates are not blocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->