### PR TITLE
Fix/Prevent from pausing reviews when addressing comments

### DIFF
--- a/coderabbit/python/ai/v1/.coderabbit.yaml
+++ b/coderabbit/python/ai/v1/.coderabbit.yaml
@@ -9,7 +9,7 @@ reviews:
     auto_review:
         enabled: true
         auto_incremental_review: true
-        auto_pause_after_reviewed_commits: false
+        auto_pause_after_reviewed_commits: 0
         base_branches:
             - '^(?!release).*'
     poem: false

--- a/coderabbit/python/ai/v1/.coderabbit.yaml
+++ b/coderabbit/python/ai/v1/.coderabbit.yaml
@@ -9,6 +9,7 @@ reviews:
     auto_review:
         enabled: true
         auto_incremental_review: true
+        auto_pause_after_reviewed_commits: false
         base_branches:
             - '^(?!release).*'
     poem: false


### PR DESCRIPTION
When addressing CR comments, after a moment CodeRabbit automatically pauses the reviews as we push the corrected code, which may be annoying and makes us lose time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to control automatic pausing behavior after commits are reviewed. Users can now enable this feature to pause review operations when desired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->