### PR TITLE
chore: add i18n instruction

### DIFF
--- a/coderabbit/js/fe/v1/.coderabbit.yaml
+++ b/coderabbit/js/fe/v1/.coderabbit.yaml
@@ -50,6 +50,7 @@ reviews:
               Classes, Functions and Methods must be concise and have descriptive names.
               Code should follow DRY principle, and composition over inheritance.
               Code should follow development best practices.
+              All texts should be internationalized; avoid hardcoded strings in the codebase.
 
         - path: '**/*.svelte'
           instructions: |


### PR DESCRIPTION
Add instruction to fe code checks to ensure texts are internationalized

[Follow up PR](https://github.com/oat-sa/live-design-system/pull/1665) which add `.coderabbit.yaml` to LDS

### Description

This is a follow up for https://oat-sa.atlassian.net/browse/UCH-84 which exposed the issue. Usually the lack of translations only detected by customer in staging/prod environments and bring a lot of costs to backport translations, especially if root cause is in LDS missing labels.

Test PR with coderabbit's highlight of the missing translation: https://github.com/oat-sa/live-design-system/pull/1664#pullrequestreview-4796392198


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review guidance to encourage internationalized text and discourage hardcoded strings in JavaScript and Svelte code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->