### PR TITLE
chore: uch-86 - Update coderabbit instructions to prevent mapping for i18 translations in modules

### DIFF
--- a/coderabbit/js/fe/v1/.coderabbit.yaml
+++ b/coderabbit/js/fe/v1/.coderabbit.yaml
@@ -39,7 +39,7 @@ reviews:
           instructions: |
               Prefer ES modules: use import syntax, avoid require; configure type: module in package.json.
               Controllers must delegate to services, contain no business logic, and follow Single Responsibility Principle.
-              Never call __() in module-level maps or constants (e.g. { key: __('...') }); locale is set after import. Use a lookup function with literal __('...') per string instead (see src/constants/roles.js).
+              Never call __() in module-level maps or constants (e.g. { key: __('...') }); locale is set after import. Use a lookup function that calls __('...') at runtime instead (e.g. export function getRoleLabel(key) { return { admin: __('Admin') }[key]; }).
 
         - path: '**/*.{js,svelte}'
           instructions: |

--- a/coderabbit/js/fe/v1/.coderabbit.yaml
+++ b/coderabbit/js/fe/v1/.coderabbit.yaml
@@ -39,6 +39,7 @@ reviews:
           instructions: |
               Prefer ES modules: use import syntax, avoid require; configure type: module in package.json.
               Controllers must delegate to services, contain no business logic, and follow Single Responsibility Principle.
+              Never call __() in module-level maps or constants (e.g. { key: __('...') }); locale is set after import. Use a lookup function with literal __('...') per string instead (see src/constants/roles.js).
 
         - path: '**/*.{js,svelte}'
           instructions: |


### PR DESCRIPTION
**Ticket:**
https://oat-sa.atlassian.net/browse/UCH-86

**Description:**
Add a CodeRabbit review rule for a recurring frontend i18n bug: calling __() in module-level maps/constants before the application locale is initialized.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated review guidance for localized text usage.
  * Added a rule to ensure translations are resolved at runtime rather than during module initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->